### PR TITLE
Configurable reference genome in Genome Nexus VEP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+.idea
+*.iml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:latest
+FROM maven:3.5.4
 RUN mkdir /genome-nexus-vep
 ADD . /genome-nexus-vep
 WORKDIR /genome-nexus-vep

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
+FROM maven:latest
+RUN mkdir /genome-nexus-vep
+ADD . /genome-nexus-vep
+WORKDIR /genome-nexus-vep
+RUN mvn -DskipTests clean install
+
 FROM ensemblorg/ensembl-vep:release_92.1
 USER root
 RUN apt-get update && apt-get -y install openjdk-8-jre
+COPY --from=0 /genome-nexus-vep/target/vep_wrapper*.jar /opt/vep/src/ensembl-vep/vep_wrapper.jar
 USER vep
-COPY target/vep_wrapper*.jar /opt/vep/src/ensembl-vep/vep_wrapper.jar
+WORKDIR /opt/vep/src/ensembl-vep/
 ENTRYPOINT exec java ${JAVA_OPTS} -jar vep_wrapper.jar

--- a/README.md
+++ b/README.md
@@ -6,6 +6,55 @@ Ensembl VEP docker image has been extended to include the java runtime
 environment and this jar.
 
 ## Compile and run
+
+```bash
+# Point to VEP cache directory. If you don't have this cache, see section "Create VEP cache"
+VEP_CACHE=<local_vep_cache_directory_path>
+
+# Set VEP assembly, for example GRCh37 or GRCh38
+VEP_ASSEMBLY=GRCh38
+
+# Create docker image
+docker build -t genome-nexus_vep .
+
+# Run Genome-Nexus-VEP on port 8889 and point it to local cache
+docker run -d --name genome-nexus_vep -p 8889:8080 -e VEP_ASSEMBLY=$VEP_ASSEMBLY -v $VEP_CACHE:/opt/vep/.vep/:ro genome-nexus_vep:latest
 ```
-mvn  -DskipTests clean install && docker build -t genome-nexus-vep . && docker  run -p 8080:8080 -it -e "TERM=xterm-256color" genome-nexus-vep:latest
+
+Genome Nexus VEP is now running at http://localhost:8889
+
+## Create VEP cache
+If you don't have a prepared VEP cache directory, start the container with the folder mounted with ":rw" (read&write) and install the VEP cache using INSTALL.pl. Downloading and optimizing the cache will take several hours.
+
+```bash
+# Point this to your preferred directory
+VEP_CACHE=<local_vep_cache_directory_path>
+
+# Ideally this is added to ~/.bashrc or ~/.bash_profile:
+# export VEP_CACHE=<local_vep_cache_directory_path>
+# And reload this file with:
+# 'source ~/.bashrc' or 'source ~/.bash_profile'
+
+# Create docker image
+docker build -t genome-nexus_vep .
+
+# Run Genome-Nexus-VEP on port 8889 and mount cache directory with write access.
+docker run -d --name genome-nexus_vep_cache -p 8890:8080 -v $VEP_CACHE:/opt/vep/.vep/:rw genome-nexus_vep:latest
+
+# Go into the docker container
+docker exec -it genome-nexus_vep_cache bash
+
+# Run the VEP installer and follow the instructions
+# Suggested installation settings can be found below this code block
+./INSTALL.pl
+
+# When done, exit and remove the container
+exit
+docker stop genome-nexus_vep_cache; docker rm genome-nexus_vep_cache;
+
 ```
+Installation instructions:
+- Do you want to continue installing the API (y/n)? -> n
+- Do you want to install any cache files (y/n)? -> y, install GRCh37 or GRCh38 cache
+- Do you want to install any FASTA files (y/n)? -> y, install GRCh37 or GRCh38 FASTA
+- Do you want to install any plugins (y/n)? -> n

--- a/src/main/java/org/genomenexus/vep_wrapper/VepController.java
+++ b/src/main/java/org/genomenexus/vep_wrapper/VepController.java
@@ -19,10 +19,12 @@ public class VepController {
     @RequestMapping(value = "/vep/human/region/{region}/{allele}",
         method = RequestMethod.GET,
         produces = "application/json")
-    @ApiOperation(value = "Retrieves VEP results for single variant specified in region syntax e.g. 17:41242962-41242965:1/GA (https://ensembl.org/info/docs/tools/vep/vep_formats.html)",
+    @ApiOperation(value = "Retrieves VEP results for single variant specified in region syntax (https://ensembl.org/info/docs/tools/vep/vep_formats.html)",
         nickname = "fetchVepAnnotationByRegionGET")
-    public String getVepAnnotation(@ApiParam(value="region", required=true) @PathVariable String region,
-                                   @ApiParam(value="allele", required=true) @PathVariable String allele)
+    public String getVepAnnotation(@ApiParam(value="GRCh37: 17:41242962-41242965," +
+                                                   "GRCh38: 1:182712-182712", required=true) @PathVariable String region,
+                                   @ApiParam(value="GRCh37: GA, " +
+                                                   "GRCh38: C", required=true) @PathVariable String allele)
     {
         try {
             return VepRunner.run(Arrays.asList(region + "/" + allele), false);
@@ -39,7 +41,15 @@ public class VepController {
     @ApiOperation(value = "Retrieves VEP annotations for multiple variants specified in region syntax (https://ensembl.org/info/docs/tools/vep/vep_formats.html)",
         nickname = "fetchVepAnnotationByRegionsPOST")
     public String fetchVepAnnotationByRegionsPOST(
-        @ApiParam(value = "List of variants in ensembl region format. For example [\"17:41242962-41242965:1/GA\"]",
+        @ApiParam(value = "List of variants in ENSEMBL region format. For example:\n" +
+                "GRCh37: " +
+                "[\"17:41242962-41242965:1/GA\"], " +
+                "GRCh38: " +
+                "[\"1:182712-182712:1/C\", " +
+                "\"2:265023-265023:1/T\"," +
+                "\"3:319781-319781:1/-\", " +
+                "\"19:110748-110747:1/T\", " +
+                "\"1:1385015-1387562:1/-\"]",
         required = true)
         @RequestBody List<String> regions)
     {

--- a/src/main/java/org/genomenexus/vep_wrapper/VepRunner.java
+++ b/src/main/java/org/genomenexus/vep_wrapper/VepRunner.java
@@ -21,8 +21,6 @@ public class VepRunner {
         String vepParameters = System.getProperty("vep.params", String.join(" ",
             "--cache",
             "--offline",
-            "--fasta",
-            "/opt/vep/.vep/homo_sapiens/92_GRCh37/Homo_sapiens.GRCh37.75.dna.primary_assembly.fa.gz",
             "--everything",
             "--hgvsg",
             "--assembly",
@@ -40,6 +38,12 @@ public class VepRunner {
         commands.add("vep");
         for (String param : vepParameters.split(" ")) {
             commands.add(param);
+        }
+
+        // Check reference genome environment variable and replace ref genome if necessary
+        String assembly = System.getenv("VEP_ASSEMBLY");
+        if (assembly != null && !"".equals(assembly)) {
+            commands = replaceOptValue(commands, "--assembly", assembly);
         }
 
         //Run macro on target
@@ -88,5 +92,34 @@ public class VepRunner {
 
         //Abnormal termination: Log command parameters and output and throw ExecutionException
         return out.toString();
+    }
+
+    /**
+     * Function to replace a specific value in the VEP parameters list.
+     */
+    private static List<String> replaceOptValue(List<String> commands, String optionName, String newValue) {
+        List<String> result = new ArrayList<String>();
+        boolean substituteNext = false;
+        for (String command : commands) {
+
+            // Find argument to replace
+            if (command.equals(optionName)) {
+                result.add(command);
+
+                // Replace value
+                result.add(newValue);
+                substituteNext = true;
+
+            } else {
+
+                // Skip value if it was replaced in the previous iteration
+                if (substituteNext) {
+                    substituteNext = false;
+                } else {
+                    result.add(command);
+                }
+            }
+        }
+        return result;
     }
 }


### PR DESCRIPTION
- Update documentation on how to set up VEP cache
- Create environment variable that will be used by java code to specify reference genome for VEP `--assembly` parameter
- Move Maven build step to Dockerfile
- Add tested GRCh38 variants to API documentation.