### PR TITLE
Use openjdk 11 for Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.5.4
+FROM maven:3-openjdk-11
 RUN mkdir /genome-nexus-vep
 ADD . /genome-nexus-vep
 WORKDIR /genome-nexus-vep
@@ -6,7 +6,7 @@ RUN mvn -DskipTests clean install
 
 FROM ensemblorg/ensembl-vep:release_98.3
 USER root
-RUN apt-get update && apt-get -y install openjdk-8-jre
+RUN apt-get update && apt-get -y install openjdk-11-jre-headless
 COPY --from=0 /genome-nexus-vep/target/vep_wrapper*.jar /opt/vep/src/ensembl-vep/vep_wrapper.jar
 USER vep
 WORKDIR /opt/vep/src/ensembl-vep/


### PR DESCRIPTION
As the codebase depends on Spring Boot 2.0, it can run on Java 11.
I updated the Dokerfile to build and run on Java 11.