### PR TITLE
Improve performance and error handling

### DIFF
--- a/src/main/java/org/genomenexus/vep_wrapper/VEPController.java
+++ b/src/main/java/org/genomenexus/vep_wrapper/VEPController.java
@@ -77,7 +77,7 @@ public class VEPController {
             return ResponseEntity.internalServerError().body(body);
         }
 
-        List<List<String>> variantChunks = vepService.getVariantChunks(variantList, 1);
+        List<List<String>> variantChunks = vepService.getVariantChunks(variantList, 200);
         try {
             return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(vepService.annotateVariants(variantChunks, format));
         } catch (Exception e) {

--- a/src/main/java/org/genomenexus/vep_wrapper/VEPController.java
+++ b/src/main/java/org/genomenexus/vep_wrapper/VEPController.java
@@ -47,8 +47,7 @@ public class VEPController {
         try {
             String result = vepService.annotateVariants(variantChunks, format);
             // For single variant GET, check if result is only an error object
-            if (result.contains("\"successfully_annotated\":false") && !result.contains("\"successfully_annotated\":true")
-                && !result.contains("\"most_severe_consequence\"")) {
+            if (result.contains("\"successfully_annotated\":false")) {
                 Map<String, String> errorBody = constructErrorMessage(new Exception(
                     extractErrorFromResult(result)));
                 return ResponseEntity.badRequest().body(errorBody);
@@ -67,9 +66,8 @@ public class VEPController {
     public ResponseEntity<Object> annotateHGVS(@RequestBody Map<String, List<String>> variants) {
         List<String> variantList = variants.get("hgvs_notations");
         if (variantList == null) {
-            return ResponseEntity.badRequest().body(("Missing key: 'hgvs_notations'"));
+            return ResponseEntity.badRequest().body(constructErrorMessage(new Exception("Missing key: 'hgvs_notations'")));
         }
-
         Optional<String> format = Optional.of("hgvs");
         List<String> errors = new ArrayList<>();
         if (vepConfiguration.mode == VEPConfiguration.Mode.Cache) {
@@ -87,14 +85,16 @@ public class VEPController {
 
         if (variantList.isEmpty()) {
             // All variants failed conversion — return 400 with error details
-            Map<String, Object> body = new HashMap<>(constructErrorMessage(new Exception("Could not annotate any variants")));
+            Map<String, Object> body = new HashMap<>();
+            body.put("error", "Could not annotate any variants");
             body.put("details", errors);
             return ResponseEntity.badRequest().body(body);
         }
         // set chunk size to 200, as 100-200 has the best balance between parallelism and per-process efficiency
         List<List<String>> variantChunks = vepService.getVariantChunks(variantList, 200);
         try {
-            return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(vepService.annotateVariants(variantChunks, format));
+            String result = vepService.annotateVariants(variantChunks, format);
+            return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result);
         } catch (Exception e) {
             return ResponseEntity.internalServerError().body(constructErrorMessage(e));
         }

--- a/src/main/java/org/genomenexus/vep_wrapper/VEPController.java
+++ b/src/main/java/org/genomenexus/vep_wrapper/VEPController.java
@@ -45,8 +45,20 @@ public class VEPController {
         List<List<String>> variantChunks = new ArrayList<>();
         variantChunks.add(Arrays.asList(variant));
         try {
-            return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(vepService.annotateVariants(variantChunks, format));
+            String result = vepService.annotateVariants(variantChunks, format);
+            // For single variant GET, check if result is only an error object
+            if (result.contains("\"successfully_annotated\":false") && !result.contains("\"successfully_annotated\":true")
+                && !result.contains("\"most_severe_consequence\"")) {
+                Map<String, String> errorBody = constructErrorMessage(new Exception(
+                    extractErrorFromResult(result)));
+                return ResponseEntity.badRequest().body(errorBody);
+            }
+            return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result);
         } catch (Exception e) {
+            String msg = e.getMessage();
+            if (msg != null && (msg.contains("does not match reference allele") || msg.contains("Unable to parse"))) {
+                return ResponseEntity.badRequest().body(constructErrorMessage(e));
+            }
             return ResponseEntity.internalServerError().body(constructErrorMessage(e));
         }
     }
@@ -62,21 +74,24 @@ public class VEPController {
         List<String> errors = new ArrayList<>();
         if (vepConfiguration.mode == VEPConfiguration.Mode.Cache) {
             format = Optional.empty();
+            List<String> convertedVariants = new ArrayList<>();
             for (int i = 0; i < variantList.size(); i++) {
                 try {
-                     variantList.set(i, hgvsgToEnsembl(variantList.get(i)));
+                     convertedVariants.add(hgvsgToEnsembl(variantList.get(i)));
                 } catch (IllegalArgumentException e) {
                      errors.add(e.getMessage());
                 }
             }
+            variantList = convertedVariants;
         }
 
-        if (!errors.isEmpty()) {
-            Map<String, Object> body = new HashMap<>(constructErrorMessage(new Exception("Could not annotate variants")));
+        if (variantList.isEmpty()) {
+            // All variants failed conversion — return 400 with error details
+            Map<String, Object> body = new HashMap<>(constructErrorMessage(new Exception("Could not annotate any variants")));
             body.put("details", errors);
-            return ResponseEntity.internalServerError().body(body);
+            return ResponseEntity.badRequest().body(body);
         }
-
+        // set chunk size to 200, as 100-200 has the best balance between parallelism and per-process efficiency
         List<List<String>> variantChunks = vepService.getVariantChunks(variantList, 200);
         try {
             return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(vepService.annotateVariants(variantChunks, format));
@@ -120,6 +135,18 @@ public class VEPController {
 
     private Map<String, String> constructErrorMessage(Exception e) {
         return Map.of("error", e.getMessage());
+    }
+
+    /**
+     * Extract the error message from a VEP JSON result that contains only error objects.
+     */
+    private String extractErrorFromResult(String result) {
+        Pattern errorPattern = Pattern.compile("\"error\":\"([^\"]+)\"");
+        Matcher matcher = errorPattern.matcher(result);
+        if (matcher.find()) {
+            return matcher.group(1).replace("\\n", "\n").replace("\\\"", "\"");
+        }
+        return "Variant annotation failed";
     }
 
     // As of 04/01/26, hgvs variants of types 'inv' and 'dup' will never be passed to VEP

--- a/src/main/java/org/genomenexus/vep_wrapper/VEPController.java
+++ b/src/main/java/org/genomenexus/vep_wrapper/VEPController.java
@@ -54,10 +54,6 @@ public class VEPController {
             }
             return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result);
         } catch (Exception e) {
-            String msg = e.getMessage();
-            if (msg != null && (msg.contains("does not match reference allele") || msg.contains("Unable to parse"))) {
-                return ResponseEntity.badRequest().body(constructErrorMessage(e));
-            }
             return ResponseEntity.internalServerError().body(constructErrorMessage(e));
         }
     }

--- a/src/main/java/org/genomenexus/vep_wrapper/VEPController.java
+++ b/src/main/java/org/genomenexus/vep_wrapper/VEPController.java
@@ -133,9 +133,7 @@ public class VEPController {
         return Map.of("error", e.getMessage());
     }
 
-    /**
-     * Extract the error message from a VEP JSON result that contains only error objects.
-     */
+    // Extract the error message from a VEP JSON result that contains only error objects.
     private String extractErrorFromResult(String result) {
         Pattern errorPattern = Pattern.compile("\"error\":\"([^\"]+)\"");
         Matcher matcher = errorPattern.matcher(result);

--- a/src/main/java/org/genomenexus/vep_wrapper/VEPResult.java
+++ b/src/main/java/org/genomenexus/vep_wrapper/VEPResult.java
@@ -2,18 +2,18 @@ package org.genomenexus.vep_wrapper;
 
 public class VEPResult {
     private String output;
-    private int exitCode;
+    private String stderr;
 
-    VEPResult(String output, int exitCode) {
+    VEPResult(String output, String stderr) {
         this.output = output;
-        this.exitCode = exitCode;
+        this.stderr = stderr;
     }
 
     public String getOutput() {
         return output;
     }
 
-    public int getExitCode() {
-        return exitCode;
+    public String getStderr() {
+        return stderr;
     }
 }

--- a/src/main/java/org/genomenexus/vep_wrapper/VEPService.java
+++ b/src/main/java/org/genomenexus/vep_wrapper/VEPService.java
@@ -32,6 +32,7 @@ public class VEPService {
     private static final Pattern VEP_VERSION_PATTERN = Pattern.compile("ensembl-vep\\s*:\\s*(\\d+)");
     private static final Pattern VEP_FAILED_REGION_PATTERN = Pattern.compile("\\+ (\\S+)$", Pattern.MULTILINE);
     private static final Pattern VEP_OUTPUT_INPUT_PATTERN = Pattern.compile("\"input\":\\s*\"([^\"]+)\"");
+    private static final Pattern VEP_MSG_PATTERN = Pattern.compile("MSG:\\s*(.*)");
 
     @Autowired
     private VEPConfiguration vepConfiguration;
@@ -72,8 +73,6 @@ public class VEPService {
                 outputBuilder.append(result.getOutput());
             }
             // Find any input variants absent from VEP's output and record them as failures.
-            // This catches both the mixed case (VEP exits 0, bad variants silently skipped)
-            // and the all-bad case (VEP exits 0 with empty stdout).
             Set<String> annotatedIds = extractAnnotatedIds(result.getOutput());
             for (String input : variantChunks.get(i)) {
                 String id = extractVariantIdFromInput(input);
@@ -110,11 +109,9 @@ public class VEPService {
         return "[" + result.toString() + "]";
     }
 
-    /**
-     * Extract variant ID from VEP input line.
-     * For region format: "1 1020385 1020385 N/A + 1:g.1020385C>A" → "1:g.1020385C>A"
-     * For hgvs format: "1:g.1020385C>A" → "1:g.1020385C>A"
-     */
+    // Extract variant ID from VEP input line.
+    // For region format: "1 1020385 1020385 N/A + 1:g.1020385C>A" → "1:g.1020385C>A"
+    // For hgvs format: "1:g.1020385C>A" → "1:g.1020385C>A"
     private String extractVariantIdFromInput(String input) {
         Matcher matcher = VEP_FAILED_REGION_PATTERN.matcher(input);
         if (matcher.find()) {
@@ -140,18 +137,31 @@ public class VEPService {
         return ids;
     }
 
-    // Stderr for a failed chunk may contain errors for multiple variants. Split by
-    // "WARNING:" blocks and return the block that mentions variantId, so each
-    // failed variant gets its own specific error rather than the first one in the file.
+    // Extracts the relevant error lines from VEP stderr for a specific variant.
+    // VEP writes one WARNING: line per failed variant containing the variant ID, and optionally a MSG: line with extra detail.
+    // db mode:    "WARNING: Unable to parse HGVS notation '<id>' Reference allele ... does not match ..."
+    //             "WARNING: Unable to parse HGVS notation '<id>'" (bad chromosome)
+    // cache mode: "WARNING: variant skipped (<ensembl-format> + <id>): Chromosome N not found ..."
+    //             wrong ref allele is silently corrected via --lookup_ref and does not appear in stderr
     private String extractVariantError(String variantId, String stderr) {
         if (!StringUtils.hasText(stderr)) return "";
-        String[] blocks = stderr.split("(?=WARNING:)");
-        for (String block : blocks) {
-            if (block.contains(variantId)) {
-                return block.trim();
-            }
+
+        String warning = null;
+        Matcher warningMatcher = Pattern.compile("WARNING:.*" + Pattern.quote(variantId) + ".*").matcher(stderr);
+        if (warningMatcher.find()) {
+            warning = warningMatcher.group();
         }
-        return stderr.trim();
+
+        String msg = null;
+        Matcher msgMatcher = VEP_MSG_PATTERN.matcher(stderr);
+        if (msgMatcher.find()) {
+            msg = msgMatcher.group(1);
+        }
+
+        if (warning != null && msg != null) return warning + " " + msg;
+        if (warning != null) return warning;
+        if (msg != null) return msg;
+        return "";
     }
 
     private List<String> buildBaseFlags(Optional<String> format) {

--- a/src/main/java/org/genomenexus/vep_wrapper/VEPService.java
+++ b/src/main/java/org/genomenexus/vep_wrapper/VEPService.java
@@ -30,12 +30,8 @@ import jakarta.annotation.PreDestroy;
 public class VEPService {
 
     private static final Pattern VEP_VERSION_PATTERN = Pattern.compile("ensembl-vep\\s*:\\s*(\\d+)");
-    private static final Pattern VEP_FAILED_HGVS_PATTERN = Pattern.compile("HGVS notation '([^']+)'");
     private static final Pattern VEP_FAILED_REGION_PATTERN = Pattern.compile("\\+ (\\S+)$", Pattern.MULTILINE);
-    private static final Pattern VEP_OUTPUT_INPUT_PATTERN = Pattern.compile("\"input\":\"([^\"]+)\"");
-    private static final Pattern REF_ALLELE_MISMATCH_PATTERN = Pattern.compile(
-        "Reference allele extracted from \\S+ \\(([^)]+)\\) does not match reference allele given by HGVS notation (\\S+) \\(([^)]+)\\)");
-    private static final Pattern COULD_NOT_PARSE_PATTERN = Pattern.compile("Could not parse.*HGVS notation (\\S+)");
+    private static final Pattern VEP_OUTPUT_INPUT_PATTERN = Pattern.compile("\"input\":\\s*\"([^\"]+)\"");
 
     @Autowired
     private VEPConfiguration vepConfiguration;
@@ -102,9 +98,9 @@ public class VEPService {
             if (result.length() > 0) {
                 result.append(",");
             }
-            String detailedError = formatVepErrorMessage(failed.input, failed.error);
+            String error = StringUtils.hasText(failed.error) ? failed.error : "Annotation failed";
             result.append(String.format("{\"input\":\"%s\",\"error\":\"%s\",\"successfully_annotated\":false}",
-                escapeJson(failed.input), escapeJson(detailedError)));
+                escapeJson(failed.input), escapeJson(error)));
         }
 
         if (result.length() == 0) {
@@ -156,47 +152,6 @@ public class VEPService {
             }
         }
         return stderr.trim();
-    }
-
-    // Format VEP error message
-    private String formatVepErrorMessage(String variantInput, String rawError) {
-        if (rawError == null || rawError.isEmpty()) {
-            return "Unknown error annotating variant: " + variantInput;
-        }
-
-        // Reference allele mismatch — extract alleles from VEP's message
-        Matcher refMatcher = REF_ALLELE_MISMATCH_PATTERN.matcher(rawError);
-        if (refMatcher.find()) {
-            String genomeAllele = refMatcher.group(1);
-            String notation = refMatcher.group(2);
-            String inputAllele = refMatcher.group(3);
-            return String.format(
-                "%s: Reference allele extracted from input (%s) does not match reference allele from genome (%s)",
-                notation, inputAllele, genomeAllele);
-        }
-
-        // Could not parse HGVS notation
-        Matcher parseMatcher = COULD_NOT_PARSE_PATTERN.matcher(rawError);
-        if (parseMatcher.find()) {
-            String notation = parseMatcher.group(1);
-            return String.format(
-                "Invalid HGVS notation '%s': could not be parsed. ", notation);
-        }
-
-        // Contains HGVS notation reference but unknown sub-error
-        Matcher hgvsMatcher = VEP_FAILED_HGVS_PATTERN.matcher(rawError);
-        if (hgvsMatcher.find()) {
-            String notation = hgvsMatcher.group(1);
-            if (rawError.contains("not found in database") || rawError.contains("Could not find")
-                || rawError.contains("uninitialized value") || rawError.contains("Can't call method")) {
-                return String.format(
-                    "Chromosome or position not found: variant '%s' - chromosome or position does not exist in the genome assembly.", notation);
-            }
-        }
-
-        // Fallback: return raw error with variant context
-        return String.format("Error annotating variant '%s': %s",
-            variantInput, rawError.trim().replace("\n", " "));
     }
 
     private List<String> buildBaseFlags(Optional<String> format) {

--- a/src/main/java/org/genomenexus/vep_wrapper/VEPService.java
+++ b/src/main/java/org/genomenexus/vep_wrapper/VEPService.java
@@ -21,11 +21,33 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+
 @Service
 public class VEPService {
 
+    private static final Pattern VEP_VERSION_PATTERN = Pattern.compile("ensembl-vep\\s*:\\s*(\\d+)");
+    private static final Pattern VEP_WARNING_PATTERN = Pattern.compile("WARNING:\\s(.*)\\n");
+    private static final Pattern VEP_MESSAGE_PATTERN = Pattern.compile("MSG:\\s(.*)\\n");
+
     @Autowired
     private VEPConfiguration vepConfiguration;
+
+    private ExecutorService chunkExecutor;
+    private volatile Integer cachedVepVersion;
+
+    @PostConstruct
+    public void init() {
+        this.chunkExecutor = Executors.newFixedThreadPool(vepConfiguration.hgvsMaxThreads);
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        if (chunkExecutor != null) {
+            chunkExecutor.shutdownNow();
+        }
+    }
 
     public String annotateVariants(List<List<String>> variantChunks, Optional<String> format) throws Exception {
         List<Callable<VEPResult>> wrappers = new ArrayList<>();
@@ -65,6 +87,9 @@ public class VEPService {
                 );
             }
         }
+        if (vepConfiguration.polyphenSiftFilename.isPresent() || vepConfiguration.alphaMissenseFilename.isPresent()) {
+            flags.add("--dir_plugins=/plugin-data");
+        }
         if (vepConfiguration.polyphenSiftFilename.isPresent()) {
             flags.add("--plugin=PolyPhen_SIFT,db=/plugin-data/" + vepConfiguration.polyphenSiftFilename.get());
         }
@@ -78,16 +103,15 @@ public class VEPService {
             wrappers.add(runVEP(chunkFlags));
         }
 
-        String output = "";
-        ExecutorService threadPool = Executors.newCachedThreadPool();
-        List<Future<VEPResult>> resultFutures = threadPool.invokeAll(wrappers);
+        StringBuilder outputBuilder = new StringBuilder();
+        List<Future<VEPResult>> resultFutures = chunkExecutor.invokeAll(wrappers);
 
         Exception exception = null;
         boolean allFailed = true;
         for (Future<VEPResult> resultFuture : resultFutures) {
             VEPResult result = resultFuture.get();
             if (result.getExitCode() == 0) {
-                output += result.getOutput();
+                outputBuilder.append(result.getOutput());
                 allFailed = false;
             } else if (exception == null) { // Ensembl VEP API only returns first error, so copying behavior
                 exception = new Exception(result.getOutput());
@@ -98,6 +122,7 @@ public class VEPService {
             throw exception;
         }
 
+        String output = outputBuilder.toString();
         output = output.replace("sift_pred", "sift_prediction");
         output = output.replace("polyphen_humvar_pred", "polyphen_prediction");
         output = output.replace("polyphen_humvar_score", "polyphen_score");
@@ -142,16 +167,20 @@ public class VEPService {
     }
 
     public int getVEPVersion() throws Exception {
+        Integer cached = cachedVepVersion;
+        if (cached != null) {
+            return cached;
+        }
         VEPResult result = runVEP(new ArrayList<>()).call();
         if (result.getExitCode() == 1) {
             throw new Exception(result.getOutput());
         }
 
-        String versionRegex = "ensembl-vep\\s*:\\s*(\\d+)";
-        Pattern pattern = Pattern.compile(versionRegex);
-        Matcher matcher = pattern.matcher(result.getOutput());
+        Matcher matcher = VEP_VERSION_PATTERN.matcher(result.getOutput());
         if (matcher.find()) {
-            return Integer.parseInt(matcher.group(1));
+            int version = Integer.parseInt(matcher.group(1));
+            cachedVepVersion = version;
+            return version;
         } else {
             throw new Exception("Version not found in VEP output");
         }
@@ -162,29 +191,38 @@ public class VEPService {
             @Override
             public VEPResult call() throws Exception {
                 String path = Paths.get("").toAbsolutePath().toString() + "/scripts/vep";
+                String lineSeparator = System.lineSeparator();
 
                 String output = "";
                 int exitCode = 0;
                 try {
                     flags.add(0, path);
                     Process process = new ProcessBuilder().command(flags).start();
-                         
+
                     StringBuilder outputBuilder = new StringBuilder();
                     StringBuilder errorBuilder = new StringBuilder();
-                    BufferedReader stdin = new BufferedReader(new InputStreamReader(process.getInputStream()));
-                    BufferedReader stderr = new BufferedReader(new InputStreamReader(process.getErrorStream()));
 
-                    String line = null;
-                    while ( (line = stdin.readLine()) != null) {
-                        outputBuilder.append(line);
-                        outputBuilder.append(System.getProperty("line.separator"));
+                    // Drain stderr on a separate thread so a full stderr pipe buffer
+                    // cannot deadlock VEP while we are still reading stdout.
+                    Thread stderrReader = new Thread(() -> {
+                        try (BufferedReader stderr = new BufferedReader(new InputStreamReader(process.getErrorStream()))) {
+                            String errLine;
+                            while ((errLine = stderr.readLine()) != null) {
+                                errorBuilder.append(errLine).append(lineSeparator);
+                            }
+                        } catch (IOException ignored) {
+                        }
+                    }, "vep-stderr-reader");
+                    stderrReader.setDaemon(true);
+                    stderrReader.start();
+
+                    try (BufferedReader stdin = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                        String line;
+                        while ((line = stdin.readLine()) != null) {
+                            outputBuilder.append(line).append(lineSeparator);
+                        }
                     }
-                    while ( (line = stderr.readLine()) != null) {
-                        errorBuilder.append(line);
-                        errorBuilder.append(System.getProperty("line.separator"));
-                    }    
-                    stdin.close();
-                    stderr.close();
+                    stderrReader.join();
 
                     output = outputBuilder.toString();
                     String error = errorBuilder.toString();
@@ -194,7 +232,7 @@ public class VEPService {
                     }
                 } catch (IOException e) {
                     e.printStackTrace();
-                } 
+                }
 
                 return new VEPResult(output, exitCode);
             }
@@ -205,16 +243,12 @@ public class VEPService {
         String warning = null;
         String message = null;
 
-        String warningRegex = "WARNING:\\s(.*)\\n";
-        Pattern pattern = Pattern.compile(warningRegex);
-        Matcher matcher = pattern.matcher(error);
+        Matcher matcher = VEP_WARNING_PATTERN.matcher(error);
         if (matcher.find()) {
             warning = matcher.group(1);
         }
 
-        String messageRegex =  "MSG:\\s(.*)\\n";
-        pattern = Pattern.compile(messageRegex);
-        matcher = pattern.matcher(error);
+        matcher = VEP_MESSAGE_PATTERN.matcher(error);
         if (matcher.find()) {
             message = matcher.group(1);
         }
@@ -222,7 +256,7 @@ public class VEPService {
         String output = "";
         if (warning != null) {
             output += warning;
-        } 
+        }
         if (message != null) {
             output += message;
         } else {

--- a/src/main/java/org/genomenexus/vep_wrapper/VEPService.java
+++ b/src/main/java/org/genomenexus/vep_wrapper/VEPService.java
@@ -82,7 +82,7 @@ public class VEPService {
             for (String input : variantChunks.get(i)) {
                 String id = extractVariantIdFromInput(input);
                 if (!annotatedIds.contains(id)) {
-                    failedVariants.add(new FailedVariant(id, result.getStderr()));
+                    failedVariants.add(new FailedVariant(id, extractVariantError(id, result.getStderr())));
                 }
             }
         }
@@ -144,9 +144,21 @@ public class VEPService {
         return ids;
     }
 
-    /**
-     * Format VEP error into a user-facing message.
-     */
+    // Stderr for a failed chunk may contain errors for multiple variants. Split by
+    // "WARNING:" blocks and return the block that mentions variantId, so each
+    // failed variant gets its own specific error rather than the first one in the file.
+    private String extractVariantError(String variantId, String stderr) {
+        if (!StringUtils.hasText(stderr)) return "";
+        String[] blocks = stderr.split("(?=WARNING:)");
+        for (String block : blocks) {
+            if (block.contains(variantId)) {
+                return block.trim();
+            }
+        }
+        return stderr.trim();
+    }
+
+    // Format VEP error message
     private String formatVepErrorMessage(String variantInput, String rawError) {
         if (rawError == null || rawError.isEmpty()) {
             return "Unknown error annotating variant: " + variantInput;

--- a/src/main/java/org/genomenexus/vep_wrapper/VEPService.java
+++ b/src/main/java/org/genomenexus/vep_wrapper/VEPService.java
@@ -28,8 +28,11 @@ import jakarta.annotation.PreDestroy;
 public class VEPService {
 
     private static final Pattern VEP_VERSION_PATTERN = Pattern.compile("ensembl-vep\\s*:\\s*(\\d+)");
-    private static final Pattern VEP_WARNING_PATTERN = Pattern.compile("WARNING:\\s(.*)\\n");
-    private static final Pattern VEP_MESSAGE_PATTERN = Pattern.compile("MSG:\\s(.*)\\n");
+    private static final Pattern VEP_FAILED_HGVS_PATTERN = Pattern.compile("HGVS notation '([^']+)'");
+    private static final Pattern VEP_FAILED_REGION_PATTERN = Pattern.compile("\\+ (\\S+)$", Pattern.MULTILINE);
+    private static final Pattern REF_ALLELE_MISMATCH_PATTERN = Pattern.compile(
+        "Reference allele extracted from \\S+ \\(([^)]+)\\) does not match reference allele given by HGVS notation (\\S+) \\(([^)]+)\\)");
+    private static final Pattern COULD_NOT_PARSE_PATTERN = Pattern.compile("Could not parse.*HGVS notation (\\S+)");
 
     @Autowired
     private VEPConfiguration vepConfiguration;
@@ -50,8 +53,231 @@ public class VEPService {
     }
 
     public String annotateVariants(List<List<String>> variantChunks, Optional<String> format) throws Exception {
-        List<Callable<VEPResult>> wrappers = new ArrayList<>();
+        List<String> flags = buildBaseFlags(format);
 
+        StringBuilder outputBuilder = new StringBuilder();
+        List<FailedVariant> failedVariants = new ArrayList<>();
+
+        List<Callable<VEPResult>> wrappers = new ArrayList<>();
+        for (List<String> chunk : variantChunks) {
+            List<String> chunkFlags = new ArrayList<>(flags);
+            chunkFlags.add("--input_data=" + chunk.stream().collect(Collectors.joining("\n")));
+            wrappers.add(runVEP(chunkFlags));
+        }
+
+        List<Future<VEPResult>> resultFutures = chunkExecutor.invokeAll(wrappers);
+
+        List<List<String>> failedChunks = new ArrayList<>();
+        List<VEPResult> failedResults = new ArrayList<>();
+        for (int i = 0; i < resultFutures.size(); i++) {
+            VEPResult result = resultFutures.get(i).get();
+            if (result.getExitCode() == 0) {
+                outputBuilder.append(result.getOutput());
+            } else {
+                // Chunk failed — queue for retry with individual variant identification
+                failedChunks.add(variantChunks.get(i));
+                failedResults.add(result);
+            }
+        }
+
+        // For failed chunks, identify bad variants and retry good ones
+        for (int i = 0; i < failedChunks.size(); i++) {
+            retryFailedChunk(failedChunks.get(i), failedResults.get(i), flags, outputBuilder, failedVariants);
+        }
+
+        // Build final JSON array combining successful annotations and error objects
+        String output = outputBuilder.toString();
+        output = output.replace("sift_pred", "sift_prediction");
+        output = output.replace("polyphen_humvar_pred", "polyphen_prediction");
+        output = output.replace("polyphen_humvar_score", "polyphen_score");
+
+        StringBuilder result = new StringBuilder();
+        if (!output.isEmpty()) {
+            result.append(output.replace("\n{", ",{"));
+        }
+        // Append error objects for failed variants
+        for (FailedVariant failed : failedVariants) {
+            if (result.length() > 0) {
+                result.append(",");
+            }
+            String detailedError = formatVepErrorMessage(failed.input, failed.error);
+            result.append(String.format("{\"input\":\"%s\",\"error\":\"%s\",\"successfully_annotated\":false}",
+                escapeJson(failed.input), escapeJson(detailedError)));
+        }
+
+        if (result.length() == 0) {
+            throw new Exception("All variants failed annotation");
+        }
+
+        return "[" + result.toString() + "]";
+    }
+
+    // When a batch chunk fails, identify which variant(s) caused the failure, remove them, and retry the remaining good variants as a batch.
+    private void retryFailedChunk(List<String> chunk, VEPResult initialFailure, List<String> baseFlags,
+                                   StringBuilder outputBuilder, List<FailedVariant> failedVariants) throws Exception {
+        List<String> remaining = new ArrayList<>(chunk);
+        int maxSequentialRetries = 5;
+
+        // Sequential removal — peel off up to 5 bad variants one at a time
+        VEPResult currentFailure = initialFailure;
+        for (int attempt = 0; attempt < maxSequentialRetries && !remaining.isEmpty(); attempt++) {
+            String failedId = extractFailedVariantFromError(currentFailure.getOutput(), remaining);
+            if (failedId == null) {
+                // Can't identify bad variant — go straight to binary search
+                break;
+            }
+
+            failedVariants.add(new FailedVariant(failedId, currentFailure.getOutput()));
+            remaining = remaining.stream()
+                .filter(v -> !v.contains(failedId))
+                .collect(Collectors.toList());
+
+            if (remaining.isEmpty()) return;
+
+            // Retry batch without the removed bad variant(s)
+            VEPResult retryResult = runVEPForInput(remaining, baseFlags);
+            if (retryResult.getExitCode() == 0) {
+                outputBuilder.append(retryResult.getOutput());
+                return;
+            }
+            currentFailure = retryResult;
+        }
+
+        // Binary search to isolate remaining bad variants
+        // Only reached if >5 bad variants exist or can't identify from error message
+        if (!remaining.isEmpty()) {
+            binarySearchPartition(remaining, baseFlags, outputBuilder, failedVariants);
+        }
+    }
+
+    /**
+     * Binary search partition: recursively split the variant list in half, test each half as a batch.
+     * Halves that succeed get their output appended. Halves that fail are split again.
+     * Base case: single variant that fails → record as FailedVariant.
+     */
+    private void binarySearchPartition(List<String> variants, List<String> baseFlags,
+                                        StringBuilder outputBuilder, List<FailedVariant> failedVariants) throws Exception {
+        if (variants.isEmpty()) return;
+
+        // Base case: single variant
+        if (variants.size() == 1) {
+            VEPResult result = runVEPForInput(variants, baseFlags);
+            if (result.getExitCode() == 0) {
+                outputBuilder.append(result.getOutput());
+            } else {
+                String variantId = extractVariantIdFromInput(variants.get(0));
+                failedVariants.add(new FailedVariant(variantId, result.getOutput()));
+            }
+            return;
+        }
+
+        // Try the whole list as a batch first
+        VEPResult result = runVEPForInput(variants, baseFlags);
+        if (result.getExitCode() == 0) {
+            // All variants in this subset are good
+            outputBuilder.append(result.getOutput());
+            return;
+        }
+
+        // Split in half and recurse
+        int mid = variants.size() / 2;
+        List<String> left = variants.subList(0, mid);
+        List<String> right = variants.subList(mid, variants.size());
+
+        binarySearchPartition(left, baseFlags, outputBuilder, failedVariants);
+        binarySearchPartition(right, baseFlags, outputBuilder, failedVariants);
+    }
+
+    //run VEP with a list of input variants
+    private VEPResult runVEPForInput(List<String> inputs, List<String> baseFlags) throws Exception {
+        List<String> flags = new ArrayList<>(baseFlags);
+        flags.add("--input_data=" + inputs.stream().collect(Collectors.joining("\n")));
+        return runVEP(flags).call();
+    }
+
+    /**
+     * Extract the variant that caused a VEP failure from the error message.
+     * Looks for HGVS notation in the error, or falls back to matching region format input.
+     */
+    private String extractFailedVariantFromError(String error, List<String> inputVariants) {
+        // Try to find HGVS notation in error
+        Matcher matcher = VEP_FAILED_HGVS_PATTERN.matcher(error);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        // For region format inputs, the original HGVS is appended after "+"
+        // Try matching against the input list
+        for (String input : inputVariants) {
+            String variantId = extractVariantIdFromInput(input);
+            if (error.contains(variantId)) {
+                return variantId;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Extract variant ID from VEP input line.
+     * For region format: "1 1020385 1020385 N/A + 1:g.1020385C>A" → "1:g.1020385C>A"
+     * For hgvs format: "1:g.1020385C>A" → "1:g.1020385C>A"
+     */
+    private String extractVariantIdFromInput(String input) {
+        Matcher matcher = VEP_FAILED_REGION_PATTERN.matcher(input);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        return input.trim();
+    }
+
+    private String escapeJson(String value) {
+        if (value == null) return "";
+        return value.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "");
+    }
+
+    /**
+     * Format VEP error into a user-facing message.
+     */
+    private String formatVepErrorMessage(String variantInput, String rawError) {
+        if (rawError == null || rawError.isEmpty()) {
+            return "Unknown error annotating variant: " + variantInput;
+        }
+
+        // Reference allele mismatch — extract alleles from VEP's message
+        Matcher refMatcher = REF_ALLELE_MISMATCH_PATTERN.matcher(rawError);
+        if (refMatcher.find()) {
+            String genomeAllele = refMatcher.group(1);
+            String notation = refMatcher.group(2);
+            String inputAllele = refMatcher.group(3);
+            return String.format(
+                "%s: Reference allele extracted from input (%s) does not match reference allele from genome (%s)",
+                notation, inputAllele, genomeAllele);
+        }
+
+        // Could not parse HGVS notation
+        Matcher parseMatcher = COULD_NOT_PARSE_PATTERN.matcher(rawError);
+        if (parseMatcher.find()) {
+            String notation = parseMatcher.group(1);
+            return String.format(
+                "Invalid HGVS notation '%s': could not be parsed. ", notation);
+        }
+
+        // Contains HGVS notation reference but unknown sub-error
+        Matcher hgvsMatcher = VEP_FAILED_HGVS_PATTERN.matcher(rawError);
+        if (hgvsMatcher.find()) {
+            String notation = hgvsMatcher.group(1);
+            if (rawError.contains("not found in database") || rawError.contains("Could not find")
+                || rawError.contains("uninitialized value") || rawError.contains("Can't call method")) {
+                return String.format(
+                    "Chromosome or position not found: variant '%s' - chromosome or position does not exist in the genome assembly.", notation);
+            }
+        }
+
+        // Fallback: return raw error with variant context
+        return String.format("Error annotating variant '%s': %s",
+            variantInput, rawError.trim().replace("\n", " "));
+    }
+
+    private List<String> buildBaseFlags(Optional<String> format) {
         List<String> flags = new ArrayList<>(Arrays.asList(
             "--output_file=STDOUT",
                 "--warning_file=STDERR",
@@ -60,6 +286,7 @@ public class VEPService {
                 "--no_stats",
                 "--xref_refseq",
                 "--json",
+                "--shift_hgvs=1",
                 "--fork=" + vepConfiguration.forks
         ));
         if (format.isPresent()) { // vep breaks when the format is set to ensembl (even though it should be correct)
@@ -96,38 +323,10 @@ public class VEPService {
         if (vepConfiguration.alphaMissenseFilename.isPresent()) {
             flags.add("--plugin=AlphaMissense,file=/plugin-data/" + vepConfiguration.alphaMissenseFilename.get());
         }
-
-        for (List<String> chunk : variantChunks) {
-            List<String> chunkFlags = new ArrayList<>(flags);
-            chunkFlags.add("--input_data=" + chunk.stream().collect(Collectors.joining("\n")));
-            wrappers.add(runVEP(chunkFlags));
-        }
-
-        StringBuilder outputBuilder = new StringBuilder();
-        List<Future<VEPResult>> resultFutures = chunkExecutor.invokeAll(wrappers);
-
-        Exception exception = null;
-        boolean allFailed = true;
-        for (Future<VEPResult> resultFuture : resultFutures) {
-            VEPResult result = resultFuture.get();
-            if (result.getExitCode() == 0) {
-                outputBuilder.append(result.getOutput());
-                allFailed = false;
-            } else if (exception == null) { // Ensembl VEP API only returns first error, so copying behavior
-                exception = new Exception(result.getOutput());
-            }
-        }
-
-        if (allFailed) {
-            throw exception;
-        }
-
-        String output = outputBuilder.toString();
-        output = output.replace("sift_pred", "sift_prediction");
-        output = output.replace("polyphen_humvar_pred", "polyphen_prediction");
-        output = output.replace("polyphen_humvar_score", "polyphen_score");
-        return "[" + output.replace("\n{", ",{") + "]";
+        return flags;
     }
+
+    private record FailedVariant(String input, String error) {}
 
     public List<List<String>> getVariantChunks(List<String> variants, int chunkSize) {
         List<List<String>> variantChunks = new ArrayList<>();
@@ -240,28 +439,12 @@ public class VEPService {
     }
 
     private String parseVepError(String error) {
-        String warning = null;
-        String message = null;
-
-        Matcher matcher = VEP_WARNING_PATTERN.matcher(error);
-        if (matcher.find()) {
-            warning = matcher.group(1);
+        // Return the full stderr trimmed — formatVepErrorMessage will handle
+        // pattern matching and message formatting downstream.
+        String trimmed = error.trim();
+        if (trimmed.isEmpty()) {
+            return "Error annotating variant";
         }
-
-        matcher = VEP_MESSAGE_PATTERN.matcher(error);
-        if (matcher.find()) {
-            message = matcher.group(1);
-        }
-
-        String output = "";
-        if (warning != null) {
-            output += warning;
-        }
-        if (message != null) {
-            output += message;
-        } else {
-            output += "Error annotating variant";
-        }
-        return output;
+        return trimmed;
     }
 }

--- a/src/main/java/org/genomenexus/vep_wrapper/VEPService.java
+++ b/src/main/java/org/genomenexus/vep_wrapper/VEPService.java
@@ -99,7 +99,7 @@ public class VEPService {
             }
             String error = StringUtils.hasText(failed.error) ? failed.error : "Annotation failed";
             result.append(String.format("{\"input\":\"%s\",\"error\":\"%s\",\"successfully_annotated\":false}",
-                escapeJson(failed.input), escapeJson(error)));
+                encodeJsonValue(failed.input), encodeJsonValue(error)));
         }
 
         if (result.length() == 0) {
@@ -120,7 +120,7 @@ public class VEPService {
         return input.trim();
     }
 
-    private String escapeJson(String value) {
+    private String encodeJsonValue(String value) {
         if (value == null) return "";
         return value.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "");
     }
@@ -201,9 +201,6 @@ public class VEPService {
                 );
             }
         }
-        if (vepConfiguration.polyphenSiftFilename.isPresent() || vepConfiguration.alphaMissenseFilename.isPresent()) {
-            flags.add("--dir_plugins=/plugin-data");
-        }
         if (vepConfiguration.polyphenSiftFilename.isPresent()) {
             flags.add("--plugin=PolyPhen_SIFT,db=/plugin-data/" + vepConfiguration.polyphenSiftFilename.get());
         }
@@ -281,8 +278,7 @@ public class VEPService {
                     flags.add(0, path);
                     Process process = new ProcessBuilder().command(flags).start();
 
-                    // Drain stderr on a separate thread so a full stderr pipe buffer
-                    // cannot deadlock VEP while we are still reading stdout.
+                    // Drain stderr on a separate thread so a full stderr pipe buffer cannot deadlock VEP while we are still reading stdout.
                     Thread stderrReader = new Thread(() -> {
                         try (BufferedReader stderr = new BufferedReader(new InputStreamReader(process.getErrorStream()))) {
                             String errLine;

--- a/src/main/java/org/genomenexus/vep_wrapper/VEPService.java
+++ b/src/main/java/org/genomenexus/vep_wrapper/VEPService.java
@@ -7,8 +7,10 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -30,6 +32,7 @@ public class VEPService {
     private static final Pattern VEP_VERSION_PATTERN = Pattern.compile("ensembl-vep\\s*:\\s*(\\d+)");
     private static final Pattern VEP_FAILED_HGVS_PATTERN = Pattern.compile("HGVS notation '([^']+)'");
     private static final Pattern VEP_FAILED_REGION_PATTERN = Pattern.compile("\\+ (\\S+)$", Pattern.MULTILINE);
+    private static final Pattern VEP_OUTPUT_INPUT_PATTERN = Pattern.compile("\"input\":\"([^\"]+)\"");
     private static final Pattern REF_ALLELE_MISMATCH_PATTERN = Pattern.compile(
         "Reference allele extracted from \\S+ \\(([^)]+)\\) does not match reference allele given by HGVS notation (\\S+) \\(([^)]+)\\)");
     private static final Pattern COULD_NOT_PARSE_PATTERN = Pattern.compile("Could not parse.*HGVS notation (\\S+)");
@@ -67,22 +70,21 @@ public class VEPService {
 
         List<Future<VEPResult>> resultFutures = chunkExecutor.invokeAll(wrappers);
 
-        List<List<String>> failedChunks = new ArrayList<>();
-        List<VEPResult> failedResults = new ArrayList<>();
         for (int i = 0; i < resultFutures.size(); i++) {
             VEPResult result = resultFutures.get(i).get();
-            if (result.getExitCode() == 0) {
+            if (StringUtils.hasText(result.getOutput())) {
                 outputBuilder.append(result.getOutput());
-            } else {
-                // Chunk failed — queue for retry with individual variant identification
-                failedChunks.add(variantChunks.get(i));
-                failedResults.add(result);
             }
-        }
-
-        // For failed chunks, identify bad variants and retry good ones
-        for (int i = 0; i < failedChunks.size(); i++) {
-            retryFailedChunk(failedChunks.get(i), failedResults.get(i), flags, outputBuilder, failedVariants);
+            // Find any input variants absent from VEP's output and record them as failures.
+            // This catches both the mixed case (VEP exits 0, bad variants silently skipped)
+            // and the all-bad case (VEP exits 0 with empty stdout).
+            Set<String> annotatedIds = extractAnnotatedIds(result.getOutput());
+            for (String input : variantChunks.get(i)) {
+                String id = extractVariantIdFromInput(input);
+                if (!annotatedIds.contains(id)) {
+                    failedVariants.add(new FailedVariant(id, result.getStderr()));
+                }
+            }
         }
 
         // Build final JSON array combining successful annotations and error objects
@@ -112,110 +114,6 @@ public class VEPService {
         return "[" + result.toString() + "]";
     }
 
-    // When a batch chunk fails, identify which variant(s) caused the failure, remove them, and retry the remaining good variants as a batch.
-    private void retryFailedChunk(List<String> chunk, VEPResult initialFailure, List<String> baseFlags,
-                                   StringBuilder outputBuilder, List<FailedVariant> failedVariants) throws Exception {
-        List<String> remaining = new ArrayList<>(chunk);
-        int maxSequentialRetries = 5;
-
-        // Sequential removal — peel off up to 5 bad variants one at a time
-        VEPResult currentFailure = initialFailure;
-        for (int attempt = 0; attempt < maxSequentialRetries && !remaining.isEmpty(); attempt++) {
-            String failedId = extractFailedVariantFromError(currentFailure.getOutput(), remaining);
-            if (failedId == null) {
-                // Can't identify bad variant — go straight to binary search
-                break;
-            }
-
-            failedVariants.add(new FailedVariant(failedId, currentFailure.getOutput()));
-            remaining = remaining.stream()
-                .filter(v -> !v.contains(failedId))
-                .collect(Collectors.toList());
-
-            if (remaining.isEmpty()) return;
-
-            // Retry batch without the removed bad variant(s)
-            VEPResult retryResult = runVEPForInput(remaining, baseFlags);
-            if (retryResult.getExitCode() == 0) {
-                outputBuilder.append(retryResult.getOutput());
-                return;
-            }
-            currentFailure = retryResult;
-        }
-
-        // Binary search to isolate remaining bad variants
-        // Only reached if >5 bad variants exist or can't identify from error message
-        if (!remaining.isEmpty()) {
-            binarySearchPartition(remaining, baseFlags, outputBuilder, failedVariants);
-        }
-    }
-
-    /**
-     * Binary search partition: recursively split the variant list in half, test each half as a batch.
-     * Halves that succeed get their output appended. Halves that fail are split again.
-     * Base case: single variant that fails → record as FailedVariant.
-     */
-    private void binarySearchPartition(List<String> variants, List<String> baseFlags,
-                                        StringBuilder outputBuilder, List<FailedVariant> failedVariants) throws Exception {
-        if (variants.isEmpty()) return;
-
-        // Base case: single variant
-        if (variants.size() == 1) {
-            VEPResult result = runVEPForInput(variants, baseFlags);
-            if (result.getExitCode() == 0) {
-                outputBuilder.append(result.getOutput());
-            } else {
-                String variantId = extractVariantIdFromInput(variants.get(0));
-                failedVariants.add(new FailedVariant(variantId, result.getOutput()));
-            }
-            return;
-        }
-
-        // Try the whole list as a batch first
-        VEPResult result = runVEPForInput(variants, baseFlags);
-        if (result.getExitCode() == 0) {
-            // All variants in this subset are good
-            outputBuilder.append(result.getOutput());
-            return;
-        }
-
-        // Split in half and recurse
-        int mid = variants.size() / 2;
-        List<String> left = variants.subList(0, mid);
-        List<String> right = variants.subList(mid, variants.size());
-
-        binarySearchPartition(left, baseFlags, outputBuilder, failedVariants);
-        binarySearchPartition(right, baseFlags, outputBuilder, failedVariants);
-    }
-
-    //run VEP with a list of input variants
-    private VEPResult runVEPForInput(List<String> inputs, List<String> baseFlags) throws Exception {
-        List<String> flags = new ArrayList<>(baseFlags);
-        flags.add("--input_data=" + inputs.stream().collect(Collectors.joining("\n")));
-        return runVEP(flags).call();
-    }
-
-    /**
-     * Extract the variant that caused a VEP failure from the error message.
-     * Looks for HGVS notation in the error, or falls back to matching region format input.
-     */
-    private String extractFailedVariantFromError(String error, List<String> inputVariants) {
-        // Try to find HGVS notation in error
-        Matcher matcher = VEP_FAILED_HGVS_PATTERN.matcher(error);
-        if (matcher.find()) {
-            return matcher.group(1);
-        }
-        // For region format inputs, the original HGVS is appended after "+"
-        // Try matching against the input list
-        for (String input : inputVariants) {
-            String variantId = extractVariantIdFromInput(input);
-            if (error.contains(variantId)) {
-                return variantId;
-            }
-        }
-        return null;
-    }
-
     /**
      * Extract variant ID from VEP input line.
      * For region format: "1 1020385 1020385 N/A + 1:g.1020385C>A" → "1:g.1020385C>A"
@@ -232,6 +130,18 @@ public class VEPService {
     private String escapeJson(String value) {
         if (value == null) return "";
         return value.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "");
+    }
+
+    private Set<String> extractAnnotatedIds(String stdout) {
+        Set<String> ids = new HashSet<>();
+        if (!StringUtils.hasText(stdout)) return ids;
+        for (String line : stdout.split("\n")) {
+            Matcher m = VEP_OUTPUT_INPUT_PATTERN.matcher(line);
+            if (m.find()) {
+                ids.add(extractVariantIdFromInput(m.group(1)));
+            }
+        }
+        return ids;
     }
 
     /**
@@ -371,11 +281,7 @@ public class VEPService {
             return cached;
         }
         VEPResult result = runVEP(new ArrayList<>()).call();
-        if (result.getExitCode() == 1) {
-            throw new Exception(result.getOutput());
-        }
-
-        Matcher matcher = VEP_VERSION_PATTERN.matcher(result.getOutput());
+        Matcher matcher = VEP_VERSION_PATTERN.matcher(result.getOutput() + result.getStderr());
         if (matcher.find()) {
             int version = Integer.parseInt(matcher.group(1));
             cachedVepVersion = version;
@@ -392,14 +298,11 @@ public class VEPService {
                 String path = Paths.get("").toAbsolutePath().toString() + "/scripts/vep";
                 String lineSeparator = System.lineSeparator();
 
-                String output = "";
-                int exitCode = 0;
+                StringBuilder outputBuilder = new StringBuilder();
+                StringBuilder errorBuilder = new StringBuilder();
                 try {
                     flags.add(0, path);
                     Process process = new ProcessBuilder().command(flags).start();
-
-                    StringBuilder outputBuilder = new StringBuilder();
-                    StringBuilder errorBuilder = new StringBuilder();
 
                     // Drain stderr on a separate thread so a full stderr pipe buffer
                     // cannot deadlock VEP while we are still reading stdout.
@@ -422,29 +325,12 @@ public class VEPService {
                         }
                     }
                     stderrReader.join();
-
-                    output = outputBuilder.toString();
-                    String error = errorBuilder.toString();
-                    if (!StringUtils.hasText(output) && StringUtils.hasText(error)) {
-                        output = parseVepError(error);
-                        exitCode = 500;
-                    }
                 } catch (IOException e) {
                     e.printStackTrace();
                 }
 
-                return new VEPResult(output, exitCode);
+                return new VEPResult(outputBuilder.toString(), errorBuilder.toString());
             }
         };
-    }
-
-    private String parseVepError(String error) {
-        // Return the full stderr trimmed — formatVepErrorMessage will handle
-        // pattern matching and message formatting downstream.
-        String trimmed = error.trim();
-        if (trimmed.isEmpty()) {
-            return "Error annotating variant";
-        }
-        return trimmed;
     }
 }

--- a/src/test/java/org/genomenexus/vep_wrapper/VepErrorMessageTest.java
+++ b/src/test/java/org/genomenexus/vep_wrapper/VepErrorMessageTest.java
@@ -240,16 +240,16 @@ public class VepErrorMessageTest {
         // Check if any variant should trigger an error
         for (String variant : variants) {
             if (variant.contains("1:g.1020385C>A")) {
-                return () -> new VEPResult(REF_ALLELE_MISMATCH_ERROR, 1);
+                return () -> new VEPResult("", REF_ALLELE_MISMATCH_ERROR);
             }
             if (variant.contains("invalid_notation")) {
-                return () -> new VEPResult(COULD_NOT_PARSE_ERROR, 1);
+                return () -> new VEPResult("", COULD_NOT_PARSE_ERROR);
             }
             if (variant.contains("99:g.100A>T")) {
-                return () -> new VEPResult(NOT_FOUND_ERROR, 1);
+                return () -> new VEPResult("", NOT_FOUND_ERROR);
             }
             if (variant.contains("unknown_error_variant")) {
-                return () -> new VEPResult(UNKNOWN_ERROR, 1);
+                return () -> new VEPResult("", UNKNOWN_ERROR);
             }
         }
 
@@ -265,7 +265,7 @@ public class VepErrorMessageTest {
             }
         }
         String output = response.toString();
-        return () -> new VEPResult(output, 0);
+        return () -> new VEPResult(output, "");
     }
 
     private String readMockVariantDataFromFile(String variant) throws IOException {

--- a/src/test/java/org/genomenexus/vep_wrapper/VepErrorMessageTest.java
+++ b/src/test/java/org/genomenexus/vep_wrapper/VepErrorMessageTest.java
@@ -1,0 +1,276 @@
+package org.genomenexus.vep_wrapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+/**
+ * Tests that VEP error messages are properly formatted for different error types.
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+public class VepErrorMessageTest {
+
+    @MockitoSpyBean
+    private VEPService vepService;
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    // Simulated VEP error messages (as they appear in stderr)
+    private static final String REF_ALLELE_MISMATCH_ERROR =
+        "Unable to parse HGVS notation '1:g.1020385C>A'Reference allele extracted from " +
+        "1:1020385-1020385 (T) does not match reference allele given by HGVS notation 1:g.1020385C>A (C)";
+
+    private static final String COULD_NOT_PARSE_ERROR =
+        "Unable to parse HGVS notation 'invalid_notation'Could not parse the HGVS notation invalid_notation";
+
+    private static final String NOT_FOUND_ERROR =
+        "Unable to parse HGVS notation '99:g.100A>T'Could not find chromosome 99 not found in database";
+
+    private static final String UNKNOWN_ERROR =
+        "Something completely unexpected happened during annotation";
+
+    @BeforeEach
+    public void setup() throws Exception {
+        Answer<Callable<VEPResult>> answer = new Answer<>() {
+            @Override
+            public Callable<VEPResult> answer(InvocationOnMock invocation) throws Throwable {
+                List<String> flags = invocation.getArgument(0);
+                String flagPrefix = "--input_data=";
+                String inputData = flags.stream()
+                    .filter(flag -> flag.startsWith(flagPrefix))
+                    .findFirst()
+                    .map(flag -> flag.substring(flagPrefix.length()))
+                    .orElse("");
+
+                List<String> variants = Arrays.asList(inputData.split("\n"));
+                return constructMockedResponse(variants);
+            }
+        };
+        Mockito.when(vepService.runVEP(Mockito.anyList())).thenAnswer(answer);
+    }
+
+    @Test
+    void testRefAlleleMismatchError() throws Exception {
+        Map<String, List<String>> payload = Map.ofEntries(
+            new SimpleEntry<>("hgvs_notations", List.of("1:g.1020385C>A"))
+        );
+
+        ResponseEntity<List<Map<String, Object>>> response = restTemplate.exchange(
+            "http://localhost:" + port + "/vep/human/hgvs",
+            HttpMethod.POST,
+            new HttpEntity<>(payload),
+            new ParameterizedTypeReference<List<Map<String, Object>>>() {}
+        );
+
+        assertEquals(200, response.getStatusCode().value());
+        List<Map<String, Object>> body = response.getBody();
+        assertEquals(1, body.size());
+
+        Map<String, Object> errorResult = body.get(0);
+        assertEquals(false, errorResult.get("successfully_annotated"));
+        String error = errorResult.get("error").toString();
+        // Should contain variant ID and clear mismatch message
+        assertTrue(error.contains("1:g.1020385C>A"),
+            "Expected variant identifier in error, got: " + error);
+        assertTrue(error.contains("Reference allele extracted from input (C) does not match reference allele from genome (T)"),
+            "Expected ref allele mismatch details, got: " + error);
+    }
+
+    @Test
+    void testCouldNotParseError() throws Exception {
+        Map<String, List<String>> payload = Map.ofEntries(
+            new SimpleEntry<>("hgvs_notations", List.of("invalid_notation"))
+        );
+
+        ResponseEntity<List<Map<String, Object>>> response = restTemplate.exchange(
+            "http://localhost:" + port + "/vep/human/hgvs",
+            HttpMethod.POST,
+            new HttpEntity<>(payload),
+            new ParameterizedTypeReference<List<Map<String, Object>>>() {}
+        );
+
+        assertEquals(200, response.getStatusCode().value());
+        List<Map<String, Object>> body = response.getBody();
+        assertEquals(1, body.size());
+
+        Map<String, Object> errorResult = body.get(0);
+        assertEquals(false, errorResult.get("successfully_annotated"));
+        String error = errorResult.get("error").toString();
+        assertTrue(error.contains("Invalid HGVS notation"),
+            "Expected 'Invalid HGVS notation' message, got: " + error);
+        assertTrue(error.contains("invalid_notation"),
+            "Expected variant in error message, got: " + error);
+    }
+
+    @Test
+    void testChromosomeNotFoundError() throws Exception {
+        Map<String, List<String>> payload = Map.ofEntries(
+            new SimpleEntry<>("hgvs_notations", List.of("99:g.100A>T"))
+        );
+
+        ResponseEntity<List<Map<String, Object>>> response = restTemplate.exchange(
+            "http://localhost:" + port + "/vep/human/hgvs",
+            HttpMethod.POST,
+            new HttpEntity<>(payload),
+            new ParameterizedTypeReference<List<Map<String, Object>>>() {}
+        );
+
+        assertEquals(200, response.getStatusCode().value());
+        List<Map<String, Object>> body = response.getBody();
+        assertEquals(1, body.size());
+
+        Map<String, Object> errorResult = body.get(0);
+        assertEquals(false, errorResult.get("successfully_annotated"));
+        String error = errorResult.get("error").toString();
+        assertTrue(error.contains("Chromosome or position not found"),
+            "Expected chromosome not found message, got: " + error);
+        assertTrue(error.contains("99:g.100A>T"),
+            "Expected variant in error message, got: " + error);
+    }
+
+    @Test
+    void testUnknownError() throws Exception {
+        Map<String, List<String>> payload = Map.ofEntries(
+            new SimpleEntry<>("hgvs_notations", List.of("unknown_error_variant"))
+        );
+
+        ResponseEntity<List<Map<String, Object>>> response = restTemplate.exchange(
+            "http://localhost:" + port + "/vep/human/hgvs",
+            HttpMethod.POST,
+            new HttpEntity<>(payload),
+            new ParameterizedTypeReference<List<Map<String, Object>>>() {}
+        );
+
+        assertEquals(200, response.getStatusCode().value());
+        List<Map<String, Object>> body = response.getBody();
+        assertEquals(1, body.size());
+
+        Map<String, Object> errorResult = body.get(0);
+        assertEquals(false, errorResult.get("successfully_annotated"));
+        String error = errorResult.get("error").toString();
+        assertTrue(error.contains("Error annotating variant"),
+            "Expected fallback error message, got: " + error);
+        assertTrue(error.contains("Something completely unexpected"),
+            "Expected raw error in fallback, got: " + error);
+    }
+
+    @Test
+    void testMixedBatchWithBadAndGoodVariants() throws Exception {
+        // Mix of one bad (ref mismatch) and one good variant
+        Map<String, List<String>> payload = Map.ofEntries(
+            new SimpleEntry<>("hgvs_notations", List.of("1:g.1020385C>A", "7:g.55249071C>T"))
+        );
+
+        ResponseEntity<List<Map<String, Object>>> response = restTemplate.exchange(
+            "http://localhost:" + port + "/vep/human/hgvs",
+            HttpMethod.POST,
+            new HttpEntity<>(payload),
+            new ParameterizedTypeReference<List<Map<String, Object>>>() {}
+        );
+
+        assertEquals(200, response.getStatusCode().value());
+        List<Map<String, Object>> body = response.getBody();
+        assertEquals(2, body.size());
+
+        // Find the error and success entries
+        Map<String, Object> errorEntry = null;
+        Map<String, Object> successEntry = null;
+        for (Map<String, Object> entry : body) {
+            if (Boolean.FALSE.equals(entry.get("successfully_annotated"))) {
+                errorEntry = entry;
+            } else if (entry.containsKey("input") && "7:g.55249071C>T".equals(entry.get("input"))) {
+                successEntry = entry;
+            }
+        }
+
+        // Bad variant should have ref allele mismatch error
+        assertTrue(errorEntry != null, "Expected an error entry for the bad variant");
+        String error = errorEntry.get("error").toString();
+        assertTrue(error.contains("1:g.1020385C>A"),
+            "Expected variant identifier in ref mismatch error, got: " + error);
+        assertTrue(error.contains("does not match reference allele from genome"),
+            "Expected ref mismatch error, got: " + error);
+
+        // Good variant should be successfully annotated (present in output)
+        // It won't have "successfully_annotated" field — it's a normal VEP JSON annotation
+        boolean hasGoodVariantAnnotation = body.stream()
+            .anyMatch(entry -> !Boolean.FALSE.equals(entry.get("successfully_annotated"))
+                && entry.containsKey("input")
+                && "7:g.55249071C>T".equals(entry.get("input")));
+        assertTrue(hasGoodVariantAnnotation,
+            "Expected the good variant (7:g.55249071C>T) to be successfully annotated");
+    }
+
+    /**
+     * Construct mocked VEP responses. Variants that match known error patterns
+     * return error results (non-zero exit code); others return mock annotation data.
+     */
+    private Callable<VEPResult> constructMockedResponse(List<String> variants) {
+        // Check if any variant should trigger an error
+        for (String variant : variants) {
+            if (variant.contains("1:g.1020385C>A")) {
+                return () -> new VEPResult(REF_ALLELE_MISMATCH_ERROR, 1);
+            }
+            if (variant.contains("invalid_notation")) {
+                return () -> new VEPResult(COULD_NOT_PARSE_ERROR, 1);
+            }
+            if (variant.contains("99:g.100A>T")) {
+                return () -> new VEPResult(NOT_FOUND_ERROR, 1);
+            }
+            if (variant.contains("unknown_error_variant")) {
+                return () -> new VEPResult(UNKNOWN_ERROR, 1);
+            }
+        }
+
+        // All variants are good — return success with mock annotation JSON
+        StringBuilder response = new StringBuilder();
+        for (String variant : variants) {
+            try {
+                response.append(readMockVariantDataFromFile(variant)).append("\n");
+            } catch (IOException e) {
+                // If no mock file exists, return a minimal valid JSON
+                response.append(String.format(
+                    "{\"input\":\"%s\",\"most_severe_consequence\":\"missense_variant\"}\n", variant));
+            }
+        }
+        String output = response.toString();
+        return () -> new VEPResult(output, 0);
+    }
+
+    private String readMockVariantDataFromFile(String variant) throws IOException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String filename = variant.replace(":", "_").replace(">", "-");
+        return Files.readString(Paths.get(classLoader.getResource("mock-vep-data/" + filename + ".json").getFile()));
+    }
+}

--- a/src/test/java/org/genomenexus/vep_wrapper/VepErrorMessageTest.java
+++ b/src/test/java/org/genomenexus/vep_wrapper/VepErrorMessageTest.java
@@ -30,9 +30,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
-/**
- * Tests that VEP error messages are properly formatted for different error types.
- */
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 public class VepErrorMessageTest {
@@ -46,19 +43,7 @@ public class VepErrorMessageTest {
     @Autowired
     private TestRestTemplate restTemplate;
 
-    // Simulated VEP error messages (as they appear in stderr)
-    private static final String REF_ALLELE_MISMATCH_ERROR =
-        "Unable to parse HGVS notation '1:g.1020385C>A'Reference allele extracted from " +
-        "1:1020385-1020385 (T) does not match reference allele given by HGVS notation 1:g.1020385C>A (C)";
-
-    private static final String COULD_NOT_PARSE_ERROR =
-        "Unable to parse HGVS notation 'invalid_notation'Could not parse the HGVS notation invalid_notation";
-
-    private static final String NOT_FOUND_ERROR =
-        "Unable to parse HGVS notation '99:g.100A>T'Could not find chromosome 99 not found in database";
-
-    private static final String UNKNOWN_ERROR =
-        "Something completely unexpected happened during annotation";
+    private static final String MOCK_STDERR = "WARNING: annotation failed for bad_variant";
 
     @BeforeEach
     public void setup() throws Exception {
@@ -81,9 +66,9 @@ public class VepErrorMessageTest {
     }
 
     @Test
-    void testRefAlleleMismatchError() throws Exception {
+    void testSingleFailedVariant() throws Exception {
         Map<String, List<String>> payload = Map.ofEntries(
-            new SimpleEntry<>("hgvs_notations", List.of("1:g.1020385C>A"))
+            new SimpleEntry<>("hgvs_notations", List.of("bad_variant"))
         );
 
         ResponseEntity<List<Map<String, Object>>> response = restTemplate.exchange(
@@ -99,97 +84,14 @@ public class VepErrorMessageTest {
 
         Map<String, Object> errorResult = body.get(0);
         assertEquals(false, errorResult.get("successfully_annotated"));
-        String error = errorResult.get("error").toString();
-        // Should contain variant ID and clear mismatch message
-        assertTrue(error.contains("1:g.1020385C>A"),
-            "Expected variant identifier in error, got: " + error);
-        assertTrue(error.contains("Reference allele extracted from input (C) does not match reference allele from genome (T)"),
-            "Expected ref allele mismatch details, got: " + error);
-    }
-
-    @Test
-    void testCouldNotParseError() throws Exception {
-        Map<String, List<String>> payload = Map.ofEntries(
-            new SimpleEntry<>("hgvs_notations", List.of("invalid_notation"))
-        );
-
-        ResponseEntity<List<Map<String, Object>>> response = restTemplate.exchange(
-            "http://localhost:" + port + "/vep/human/hgvs",
-            HttpMethod.POST,
-            new HttpEntity<>(payload),
-            new ParameterizedTypeReference<List<Map<String, Object>>>() {}
-        );
-
-        assertEquals(200, response.getStatusCode().value());
-        List<Map<String, Object>> body = response.getBody();
-        assertEquals(1, body.size());
-
-        Map<String, Object> errorResult = body.get(0);
-        assertEquals(false, errorResult.get("successfully_annotated"));
-        String error = errorResult.get("error").toString();
-        assertTrue(error.contains("Invalid HGVS notation"),
-            "Expected 'Invalid HGVS notation' message, got: " + error);
-        assertTrue(error.contains("invalid_notation"),
-            "Expected variant in error message, got: " + error);
-    }
-
-    @Test
-    void testChromosomeNotFoundError() throws Exception {
-        Map<String, List<String>> payload = Map.ofEntries(
-            new SimpleEntry<>("hgvs_notations", List.of("99:g.100A>T"))
-        );
-
-        ResponseEntity<List<Map<String, Object>>> response = restTemplate.exchange(
-            "http://localhost:" + port + "/vep/human/hgvs",
-            HttpMethod.POST,
-            new HttpEntity<>(payload),
-            new ParameterizedTypeReference<List<Map<String, Object>>>() {}
-        );
-
-        assertEquals(200, response.getStatusCode().value());
-        List<Map<String, Object>> body = response.getBody();
-        assertEquals(1, body.size());
-
-        Map<String, Object> errorResult = body.get(0);
-        assertEquals(false, errorResult.get("successfully_annotated"));
-        String error = errorResult.get("error").toString();
-        assertTrue(error.contains("Chromosome or position not found"),
-            "Expected chromosome not found message, got: " + error);
-        assertTrue(error.contains("99:g.100A>T"),
-            "Expected variant in error message, got: " + error);
-    }
-
-    @Test
-    void testUnknownError() throws Exception {
-        Map<String, List<String>> payload = Map.ofEntries(
-            new SimpleEntry<>("hgvs_notations", List.of("unknown_error_variant"))
-        );
-
-        ResponseEntity<List<Map<String, Object>>> response = restTemplate.exchange(
-            "http://localhost:" + port + "/vep/human/hgvs",
-            HttpMethod.POST,
-            new HttpEntity<>(payload),
-            new ParameterizedTypeReference<List<Map<String, Object>>>() {}
-        );
-
-        assertEquals(200, response.getStatusCode().value());
-        List<Map<String, Object>> body = response.getBody();
-        assertEquals(1, body.size());
-
-        Map<String, Object> errorResult = body.get(0);
-        assertEquals(false, errorResult.get("successfully_annotated"));
-        String error = errorResult.get("error").toString();
-        assertTrue(error.contains("Error annotating variant"),
-            "Expected fallback error message, got: " + error);
-        assertTrue(error.contains("Something completely unexpected"),
-            "Expected raw error in fallback, got: " + error);
+        assertTrue(((String) errorResult.get("error")).length() > 0,
+            "Expected non-empty error message");
     }
 
     @Test
     void testMixedBatchWithBadAndGoodVariants() throws Exception {
-        // Mix of one bad (ref mismatch) and one good variant
         Map<String, List<String>> payload = Map.ofEntries(
-            new SimpleEntry<>("hgvs_notations", List.of("1:g.1020385C>A", "7:g.55249071C>T"))
+            new SimpleEntry<>("hgvs_notations", List.of("bad_variant", "7:g.55249071C>T"))
         );
 
         ResponseEntity<List<Map<String, Object>>> response = restTemplate.exchange(
@@ -203,69 +105,37 @@ public class VepErrorMessageTest {
         List<Map<String, Object>> body = response.getBody();
         assertEquals(2, body.size());
 
-        // Find the error and success entries
-        Map<String, Object> errorEntry = null;
-        Map<String, Object> successEntry = null;
-        for (Map<String, Object> entry : body) {
-            if (Boolean.FALSE.equals(entry.get("successfully_annotated"))) {
-                errorEntry = entry;
-            } else if (entry.containsKey("input") && "7:g.55249071C>T".equals(entry.get("input"))) {
-                successEntry = entry;
-            }
-        }
-
-        // Bad variant should have ref allele mismatch error
+        Map<String, Object> errorEntry = body.stream()
+            .filter(e -> Boolean.FALSE.equals(e.get("successfully_annotated")))
+            .findFirst().orElse(null);
         assertTrue(errorEntry != null, "Expected an error entry for the bad variant");
-        String error = errorEntry.get("error").toString();
-        assertTrue(error.contains("1:g.1020385C>A"),
-            "Expected variant identifier in ref mismatch error, got: " + error);
-        assertTrue(error.contains("does not match reference allele from genome"),
-            "Expected ref mismatch error, got: " + error);
+        assertTrue(((String) errorEntry.get("error")).length() > 0,
+            "Expected non-empty error message");
 
-        // Good variant should be successfully annotated (present in output)
-        // It won't have "successfully_annotated" field — it's a normal VEP JSON annotation
-        boolean hasGoodVariantAnnotation = body.stream()
-            .anyMatch(entry -> !Boolean.FALSE.equals(entry.get("successfully_annotated"))
-                && entry.containsKey("input")
-                && "7:g.55249071C>T".equals(entry.get("input")));
-        assertTrue(hasGoodVariantAnnotation,
-            "Expected the good variant (7:g.55249071C>T) to be successfully annotated");
+        boolean hasGoodVariant = body.stream()
+            .anyMatch(e -> !Boolean.FALSE.equals(e.get("successfully_annotated"))
+                && e.containsKey("input"));
+        assertTrue(hasGoodVariant, "Expected the good variant to be successfully annotated");
     }
 
-    /**
-     * Construct mocked VEP responses. Variants that match known error patterns
-     * return error results (non-zero exit code); others return mock annotation data.
-     */
     private Callable<VEPResult> constructMockedResponse(List<String> variants) {
-        // Check if any variant should trigger an error
+        StringBuilder output = new StringBuilder();
+        boolean hasBadVariant = false;
         for (String variant : variants) {
-            if (variant.contains("1:g.1020385C>A")) {
-                return () -> new VEPResult("", REF_ALLELE_MISMATCH_ERROR);
-            }
-            if (variant.contains("invalid_notation")) {
-                return () -> new VEPResult("", COULD_NOT_PARSE_ERROR);
-            }
-            if (variant.contains("99:g.100A>T")) {
-                return () -> new VEPResult("", NOT_FOUND_ERROR);
-            }
-            if (variant.contains("unknown_error_variant")) {
-                return () -> new VEPResult("", UNKNOWN_ERROR);
+            if (variant.contains("bad_variant")) {
+                hasBadVariant = true;
+            } else {
+                try {
+                    output.append(readMockVariantDataFromFile(variant)).append("\n");
+                } catch (IOException e) {
+                    output.append(String.format(
+                        "{\"input\":\"%s\",\"most_severe_consequence\":\"missense_variant\"}\n", variant));
+                }
             }
         }
-
-        // All variants are good — return success with mock annotation JSON
-        StringBuilder response = new StringBuilder();
-        for (String variant : variants) {
-            try {
-                response.append(readMockVariantDataFromFile(variant)).append("\n");
-            } catch (IOException e) {
-                // If no mock file exists, return a minimal valid JSON
-                response.append(String.format(
-                    "{\"input\":\"%s\",\"most_severe_consequence\":\"missense_variant\"}\n", variant));
-            }
-        }
-        String output = response.toString();
-        return () -> new VEPResult(output, "");
+        String stdout = output.toString();
+        String stderr = hasBadVariant ? MOCK_STDERR : "";
+        return () -> new VEPResult(stdout, stderr);
     }
 
     private String readMockVariantDataFromFile(String variant) throws IOException {

--- a/src/test/java/org/genomenexus/vep_wrapper/VepServiceTest.java
+++ b/src/test/java/org/genomenexus/vep_wrapper/VepServiceTest.java
@@ -127,7 +127,7 @@ public class VepServiceTest {
         return new Callable<VEPResult>() {
             @Override
             public VEPResult call() throws Exception {
-                return new VEPResult(response.toString(), 0);
+                return new VEPResult(response.toString(), "");
             }
         };
     }


### PR DESCRIPTION
- Raise batch HGVS chunkSize 1 → 200 in VEPController
- Replace per-request unbounded CachedThreadPool with shared bounded FixedThreadPool(hgvsMaxThreads)
- Fix potential deadlock in runVEP. Drained VEP's stderr on a separate background thread. The old stdout-then-stderr order would deadlock the application if the stderr buffer filled up first.
- When a batch has failing variants (like incorrect ref), do not remove it silently, find out the failing variants and retry others (we don't have this problem before because the batch size is hardcoded to 1, but since we changed the batch to 200 now, it makes sense to handle failing variants separately)
- Improve the error message to show whatever VEP returns